### PR TITLE
Initialize src and tests layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.env
+.venv
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # verbose-fishstick
+
+This project uses a `src/` layout for application code and a `tests/` directory for unit tests.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,6 @@
+"""Top-level package for verbose-fishstick.
+
+This module provides the package namespace for application code.
+"""
+
+__all__ = []

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit test suite for verbose-fishstick."""

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,9 @@
+"""Placeholder tests for verbose-fishstick.
+
+These tests ensure the testing framework is set up correctly.
+"""
+
+
+def test_placeholder() -> None:
+    """A sample test that always passes."""
+    assert True


### PR DESCRIPTION
## Summary
- add `src` package with `__init__.py` skeleton for future application modules
- configure tests package and placeholder test
- document project layout and ignore common Python artifacts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b7323ac448328a7433a1b40903b70