### PR TITLE
Add contributing guidelines and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,6 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+Please report any unacceptable behavior to the project maintainers.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+## Branch Strategy
+- The `main` branch contains stable, released code.
+- Create a new branch for each feature or bugfix: `git checkout -b feature/your-feature`.
+- Rebase your branch onto `main` to keep it up to date before submitting a pull request.
+
+## Coding Style
+- Follow the conventions of the language or framework in use.
+- Keep functions small and focused.
+- Write clear commit messages and include relevant tests when applicable.
+- Use descriptive names and comments where necessary.
+
+## Review Process
+- Submit a pull request against `main` when your changes are ready.
+- Ensure all tests pass and the code lints successfully.
+- A maintainer will review your pull request; please address any feedback in a timely manner.
+- Once approved, the pull request will be merged by a maintainer.
+


### PR DESCRIPTION
## Summary
- add project contribution guide covering branch strategy, coding style, and reviews
- document standard code of conduct using Contributor Covenant

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b73266a108328a43dedbe603b72c4