### PR TITLE
Add CLI for arithmetic operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,17 @@ version = "0.1.0"
 description = "A minimal project configured with pyproject.toml"
 requires-python = ">=3.9"
 dependencies = [
-    "requests>=2.0"
+    "requests>=2.0",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0",
-    "flake8>=5.0"
+    "flake8>=5.0",
 ]
+
+[project.scripts]
+verbose-fishstick = "verbose_fishstick.cli:main"
 
 [build-system]
 requires = ["setuptools>=61", "wheel"]

--- a/src/verbose_fishstick/__init__.py
+++ b/src/verbose_fishstick/__init__.py
@@ -1,13 +1,9 @@
 """Top-level package for verbose-fishstick.
 
-This module provides the package namespace for application code.
-"""
-=======
 This module provides the package namespace for application code and
-re-exports key functions for convenience."""
+re-exports key functions for convenience.
+"""
 
 from .calculator import add, subtract
 
 __all__ = ["add", "subtract"]
-
-=======

--- a/src/verbose_fishstick/cli.py
+++ b/src/verbose_fishstick/cli.py
@@ -1,0 +1,34 @@
+"""Command line interface for verbose-fishstick."""
+
+import argparse
+from .calculator import add, subtract
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the CLI."""
+    parser = argparse.ArgumentParser(description="Simple calculator")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    parser_add = subparsers.add_parser("add", help="Add two numbers")
+    parser_add.add_argument("a", type=float, help="First number")
+    parser_add.add_argument("b", type=float, help="Second number")
+
+    parser_sub = subparsers.add_parser("subtract", help="Subtract two numbers")
+    parser_sub.add_argument("a", type=float, help="First number")
+    parser_sub.add_argument("b", type=float, help="Second number")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "add":
+        result = add(args.a, args.b)
+    elif args.command == "subtract":
+        result = subtract(args.a, args.b)
+    else:
+        parser.error("Unknown command")
+        return
+
+    print(result)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1,9 +1,7 @@
-from verbose_fishstick.calculator import add, subtract
-=======
 import sys
 from pathlib import Path
 
-sys.path.append(str(Path(__file__).resolve().parent.parent / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 from verbose_fishstick import add, subtract  # noqa: E402
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = PROJECT_ROOT / "src"
+
+
+def run_cli(*args: str) -> str:
+    result = subprocess.run(
+        [sys.executable, "-m", "verbose_fishstick.cli", *args],
+        capture_output=True,
+        text=True,
+        cwd=SRC_DIR,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def test_cli_add():
+    assert float(run_cli("add", "2", "3")) == 5.0
+
+
+def test_cli_subtract():
+    assert float(run_cli("subtract", "5", "3")) == 2.0


### PR DESCRIPTION
## Summary
- implement argparse CLI with `add` and `subtract` commands
- expose console script `verbose-fishstick`
- add tests for CLI and clean existing package/tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a44705d3c08328ba05e98751caa945