### PR TITLE
refactor tests to simplify calculator imports

### DIFF
--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1,10 +1,4 @@
-from verbose_fishstick.calculator import add, subtract
-=======
-import sys
-from pathlib import Path
-
-sys.path.append(str(Path(__file__).resolve().parent.parent / "src"))
-from verbose_fishstick import add, subtract  # noqa: E402
+from verbose_fishstick import add, subtract
 
 
 def test_addition():


### PR DESCRIPTION
## Summary
- simplify calculator test imports

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'add' from 'verbose_fishstick')*

------
https://chatgpt.com/codex/tasks/task_e_68a447071638832889340e054d580612